### PR TITLE
Show commas in bank amount fields

### DIFF
--- a/Banking/bankaccount.php
+++ b/Banking/bankaccount.php
@@ -704,10 +704,10 @@
         function disallowNonNumbers(event) {
             var eventCode = event.code;
             if (eventCode) {
-                if (!eventCode.match(/Digit/)) {
+                if (!eventCode.match(/Digit/) && eventCode !== "Tab") {
                     event.preventDefault();
                 }
-            } else if (!event.char.match(/\d/)) { // IE 11
+            } else if (!event.char.match(/\d/) && event.key !== "Tab") { // IE 11
                 event.preventDefault();
             }
         }

--- a/Banking/bankaccount.php
+++ b/Banking/bankaccount.php
@@ -616,7 +616,8 @@
                         <table>
                             <tr>
                                 <th>Amount</th>
-                                <td style="height: 30px"><input type="number" name="purchaseamount" placeholder="Enter amount..." /></td>
+                                <input type="hidden" id="purchaseamount" name="purchaseamount" />
+                                <td style="height: 30px"><input type="text" class="dollaramount" placeholder="Enter amount..." data-id="purchaseamount" /></td>
                             </tr>
                             <tr>
                                 <th>Title</th>
@@ -654,7 +655,8 @@
                     <table>
                         <tr>
                             <th>Amount</th>
-                            <td><input type="number" name="transactionamount" placeholder="Enter amount..." /></td>
+                            <input type="hidden" name="transactionamount" id="transactionamount" />
+                            <td><input type="text" class="dollaramount" placeholder="Enter amount..." data-id="transactionamount" /></td>
                         </tr>
                         <tr>
                             <th>Title</th>
@@ -699,6 +701,27 @@
     </if>
 
     <script>
+        function disallowNonNumbers(event) {
+            if (!event.code.match(/Digit/)) {
+                event.preventDefault();
+            }
+        }
+
+        function addCommasToAmount(event) {
+            var inputField = event.target;
+            var mappedHiddenInputId = inputField.dataset.id;
+            var currentAmount = inputField.value.replace(/,/g, "");
+            var amountWithCommas = currentAmount.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+            inputField.value = amountWithCommas;
+            document.getElementById(mappedHiddenInputId).value = currentAmount;
+        }
+
+        var amountInputs = document.getElementsByClassName("dollaramount");
+        for (var i = 0; i < amountInputs.length; i++) {
+            amountInputs[i].addEventListener('keydown', disallowNonNumbers);
+            amountInputs[i].addEventListener('input', addCommasToAmount);
+        }
+
         $(document).on("keydown", "form", function(event) {
             return event.key != "Enter";
         });

--- a/Banking/bankaccount.php
+++ b/Banking/bankaccount.php
@@ -702,7 +702,12 @@
 
     <script>
         function disallowNonNumbers(event) {
-            if (!event.code.match(/Digit/)) {
+            var eventCode = event.code;
+            if (eventCode) {
+                if (!eventCode.match(/Digit/)) {
+                    event.preventDefault();
+                }
+            } else if (!event.char.match(/\d/)) { // IE 11
                 event.preventDefault();
             }
         }

--- a/Banking/bankaccount.php
+++ b/Banking/bankaccount.php
@@ -702,23 +702,37 @@
 
     <script>
         function disallowNonNumbers(event) {
-            var eventCode = event.code;
-            if (eventCode) {
-                if (!eventCode.match(/Digit/) && eventCode !== "Tab") {
-                    event.preventDefault();
-                }
-            } else if (!event.char.match(/\d/) && event.key !== "Tab") { // IE 11
+            var eventKey = event.key;
+            if (eventKey && !eventKey.match(/Arrow|Left$|Right$|Delete$|Backspace$|Tab$|[\d-]/)) {
                 event.preventDefault();
             }
         }
 
         function addCommasToAmount(event) {
             var inputField = event.target;
+            var valueLength = inputField.value.length;
+            var start = inputField.selectionStart;
+            var end = inputField.selectionEnd;
             var mappedHiddenInputId = inputField.dataset.id;
+            var isNegativeAmount = inputField.value.match(/-/);
             var currentAmount = inputField.value.replace(/,/g, "");
             var amountWithCommas = currentAmount.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+
+            if (isNegativeAmount) {
+                amountWithCommas = "-" + amountWithCommas.replace(/-/g, "");
+                currentAmount = "-" + currentAmount.replace(/-/g, "");
+            }
+            if (!parseInt(currentAmount)) {
+                currentAmount = 0;
+            }
+
             inputField.value = amountWithCommas;
             document.getElementById(mappedHiddenInputId).value = currentAmount;
+
+            // Make sure cursor stays in the same position in the input field
+            var newValueLength = amountWithCommas.length;
+            var lengthDiff = newValueLength - valueLength;
+            inputField.setSelectionRange(start + lengthDiff, end + lengthDiff);
         }
 
         var amountInputs = document.getElementsByClassName("dollaramount");

--- a/Banking/banksubmitrequest.php
+++ b/Banking/banksubmitrequest.php
@@ -282,7 +282,7 @@
                     echo '<tr>
                         <td>' . $xRow['username'] . '</td>
                         <input type="hidden" id="massamount_' . $massIndex . '" name="massamount_' . $massIndex . '" value="0" />
-                        <td><input type="text" class="dollaramount" value="0" data-id="massamount_' . $massIndex . '" /></td>';
+                        <td><input type="text" class="dollaramount" value="" data-id="massamount_' . $massIndex . '" /></td>';
                     if ($nameCount > 1) {
                         echo '<td><input type="text" id="massdescription_' . $massIndex . '" name="massdescription_' . $massIndex . '" /></td>';
                     }
@@ -310,23 +310,37 @@
 
     <script>
         function disallowNonNumbers(event) {
-            var eventCode = event.code;
-            if (eventCode) {
-                if (!eventCode.match(/Digit/) && eventCode !== "Tab") {
-                    event.preventDefault();
-                }
-            } else if (!event.char.match(/\d/) && event.key !== "Tab") { // IE 11
+            var eventKey = event.key;
+            if (eventKey && !eventKey.match(/Arrow|Left$|Right$|Delete$|Backspace$|Tab$|[\d-]/)) {
                 event.preventDefault();
             }
         }
 
         function addCommasToAmount(event) {
             var inputField = event.target;
+            var valueLength = inputField.value.length;
+            var start = inputField.selectionStart;
+            var end = inputField.selectionEnd;
             var mappedHiddenInputId = inputField.dataset.id;
+            var isNegativeAmount = inputField.value.match(/-/);
             var currentAmount = inputField.value.replace(/,/g, "");
             var amountWithCommas = currentAmount.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+
+            if (isNegativeAmount) {
+                amountWithCommas = "-" + amountWithCommas.replace(/-/g, "");
+                currentAmount = "-" + currentAmount.replace(/-/g, "");
+            }
+            if (!parseInt(currentAmount)) {
+                currentAmount = 0;
+            }
+
             inputField.value = amountWithCommas;
             document.getElementById(mappedHiddenInputId).value = currentAmount;
+
+            // Make sure cursor stays in the same position in the input field
+            var newValueLength = amountWithCommas.length;
+            var lengthDiff = newValueLength - valueLength;
+            inputField.setSelectionRange(start + lengthDiff, end + lengthDiff);
         }
 
         var amountInputs = document.getElementsByClassName("dollaramount");

--- a/Banking/banksubmitrequest.php
+++ b/Banking/banksubmitrequest.php
@@ -312,10 +312,10 @@
         function disallowNonNumbers(event) {
             var eventCode = event.code;
             if (eventCode) {
-                if (!eventCode.match(/Digit/)) {
+                if (!eventCode.match(/Digit/) && eventCode !== "Tab") {
                     event.preventDefault();
                 }
-            } else if (!event.char.match(/\d/)) { // IE 11
+            } else if (!event.char.match(/\d/) && event.key !== "Tab") { // IE 11
                 event.preventDefault();
             }
         }

--- a/Banking/banksubmitrequest.php
+++ b/Banking/banksubmitrequest.php
@@ -365,6 +365,9 @@
                         firstAmount = document.getElementById(idAmount).value;
                         firstDescription = document.getElementById(idDescription).value;
                     } else {
+                        var visibleAmountField = document.querySelector("input[data-id='" + idAmount + "']");
+                        visibleAmountField.value = firstAmount;
+                        visibleAmountField.dispatchEvent(new Event('input', { bubbles: true })); // To trigger value format callback
                         document.getElementById(idAmount).value = firstAmount;
                         document.getElementById(idDescription).value = firstDescription;
                     }

--- a/Banking/banksubmitrequest.php
+++ b/Banking/banksubmitrequest.php
@@ -281,7 +281,8 @@
                 while ($xRow = $db->fetch_array($xQueryNames)) {
                     echo '<tr>
                         <td>' . $xRow['username'] . '</td>
-                        <td><input type="number" id="massamount_' . $massIndex . '" name="massamount_' . $massIndex . '" value="0" /></td>';
+                        <input type="hidden" id="massamount_' . $massIndex . '" name="massamount_' . $massIndex . '" value="0" />
+                        <td><input type="text" class="dollaramount" value="0" data-id="massamount_' . $massIndex . '" /></td>';
                     if ($nameCount > 1) {
                         echo '<td><input type="text" id="massdescription_' . $massIndex . '" name="massdescription_' . $massIndex . '" /></td>';
                     }
@@ -308,6 +309,32 @@
     </div>
 
     <script>
+        function disallowNonNumbers(event) {
+            var eventCode = event.code;
+            if (eventCode) {
+                if (!eventCode.match(/Digit/)) {
+                    event.preventDefault();
+                }
+            } else if (!event.char.match(/\d/)) { // IE 11
+                event.preventDefault();
+            }
+        }
+
+        function addCommasToAmount(event) {
+            var inputField = event.target;
+            var mappedHiddenInputId = inputField.dataset.id;
+            var currentAmount = inputField.value.replace(/,/g, "");
+            var amountWithCommas = currentAmount.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+            inputField.value = amountWithCommas;
+            document.getElementById(mappedHiddenInputId).value = currentAmount;
+        }
+
+        var amountInputs = document.getElementsByClassName("dollaramount");
+        for (var i = 0; i < amountInputs.length; i++) {
+            amountInputs[i].addEventListener('keydown', disallowNonNumbers);
+            amountInputs[i].addEventListener('input', addCommasToAmount);
+        }
+
         $(document).on("keydown", ":input:not(textarea)", function(event) {
             return event.key != "Enter";
         });


### PR DESCRIPTION
I've tested the comma logic in IE 11, Edge, Firefox and Chrome. I haven't tested the actual transaction and request submit flows yet, as I think this code needs to be published to the dev forum to be able to properly test it.